### PR TITLE
fix(dashboard): revert Button asChild to Link wrapper

### DIFF
--- a/dashboard/components/dashboard/getting-started.tsx
+++ b/dashboard/components/dashboard/getting-started.tsx
@@ -69,16 +69,15 @@ const App = () => {
               Integrate the widget into your website to start collecting
               customer feedback.
             </chakra.p>
-            <Button
-              asChild
-              variant="solid"
-              w={{ base: 'full', sm: 'auto' }}
-            >
-              <a href="/docs" target="_blank" rel="noopener noreferrer">
+            <Link href="/docs" target="_blank" variant="plain">
+              <Button
+                variant="solid"
+                w={{ base: 'full', sm: 'auto' }}
+              >
                 <Text mr={1}>Documentation</Text>
                 <Icon as={LuExternalLink} />
-              </a>
-            </Button>
+              </Button>
+            </Link>
           </Box>
         </GridItem>
         <GridItem colSpan={3}>

--- a/dashboard/components/landing/hero.tsx
+++ b/dashboard/components/landing/hero.tsx
@@ -54,33 +54,35 @@ export const Heros: React.FC = () => {
           gap={2}
           justifyContent={{ sm: 'left', md: 'center' }}
         >
-          <Button
-            asChild
-            variant="solid"
-            colorPalette="teal"
-            display="inline-flex"
-            alignItems="center"
-            justifyContent="center"
-            w={{ base: 'full', sm: 'auto' }}
-            mb={{ base: 2, sm: 0 }}
-            size="lg"
-            cursor="pointer"
-          >
-            <a href="/dashboard">Dashboard</a>
-          </Button>
-          <Button
-            asChild
-            colorPalette="gray"
-            display="inline-flex"
-            alignItems="center"
-            justifyContent="center"
-            w={{ base: 'full', sm: 'auto' }}
-            mb={{ base: 2, sm: 0 }}
-            size="lg"
-            cursor="pointer"
-          >
-            <a href="/docs">Documentation</a>
-          </Button>
+          <Link href="/dashboard" variant="plain">
+            <Button
+              variant="solid"
+              colorPalette="teal"
+              display="inline-flex"
+              alignItems="center"
+              justifyContent="center"
+              w={{ base: 'full', sm: 'auto' }}
+              mb={{ base: 2, sm: 0 }}
+              size="lg"
+              cursor="pointer"
+            >
+              Dashboard
+            </Button>
+          </Link>
+          <Link href="/docs" variant="plain">
+            <Button
+              colorPalette="gray"
+              display="inline-flex"
+              alignItems="center"
+              justifyContent="center"
+              w={{ base: 'full', sm: 'auto' }}
+              mb={{ base: 2, sm: 0 }}
+              size="lg"
+              cursor="pointer"
+            >
+              Documentation
+            </Button>
+          </Link>
         </Stack>
       </Box>
       <Box

--- a/dashboard/components/landing/pricing.tsx
+++ b/dashboard/components/landing/pricing.tsx
@@ -116,22 +116,23 @@ export const Pricing: React.FC = () => {
                 </ListItem>
               </ListRoot>
 
-              <Button
-                asChild
-                mt={10}
-                w={'full'}
-                bg={'teal'}
-                color={'white'}
-                rounded={'xl'}
-                _hover={{
-                  bg: 'teal',
-                }}
-                _focus={{
-                  bg: 'teal',
-                }}
-              >
-                <a href="/dashboard">Get started</a>
-              </Button>
+              <Link href="/dashboard" variant="plain">
+                <Button
+                  mt={10}
+                  w={'full'}
+                  bg={'teal'}
+                  color={'white'}
+                  rounded={'xl'}
+                  _hover={{
+                    bg: 'teal',
+                  }}
+                  _focus={{
+                    bg: 'teal',
+                  }}
+                >
+                  Get started
+                </Button>
+              </Link>
             </Box>
           </Box>
         </Flex>


### PR DESCRIPTION
Chakra UI v3 Button does not support `asChild`. Reverted to Link-wrapping-Button pattern which renders correctly.

## Summary by Sourcery

Bug Fixes:
- Restore correct rendering and navigation for dashboard, documentation, and pricing call-to-action buttons by wrapping Buttons in Link components.