### PR TITLE
fix(ci): update lighthouse workflow to Node 22

### DIFF
--- a/.github/workflows/lighthouse.yaml
+++ b/.github/workflows/lighthouse.yaml
@@ -7,7 +7,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 22
       - name: Install dependencies
         working-directory: ./dashboard
         run: yarn install


### PR DESCRIPTION
Chakra UI v3 + Next.js 16 require Node >= 20.9. Lighthouse CI was using Node 18 causing `yarn install` to fail on `@pandacss/is-valid-prop`.

## Summary by Sourcery

CI:
- Bump Node.js version from 18 to 22 in the Lighthouse GitHub Actions workflow to prevent install failures.